### PR TITLE
Api explore

### DIFF
--- a/lib/jobs_info.rb
+++ b/lib/jobs_info.rb
@@ -20,7 +20,7 @@ def get_detailsapi_url(job_id)
 end
 
 def send_request(config, url)
-  HTTP.basic_auth(user: config['API_KEY'].to_s, pass: '').get(url)
+  HTTP.basic_auth(user: config['REED_TOKEN'].to_s, pass: '').get(url)
 end
 
 def get_detail_jd(config, job_results, api_response, job_id)


### PR DESCRIPTION
Add a script to explore REED API.

Run `ruby jobs_info.rb` in terminal, and `job_results.yml` will be saved under spec/fixtures.
`job_results.yml` contains example result of REED API.

Check:
- 11.5: flog/method average
- reek: LongParameterList: get_detail_jd has 4 parameters
- rubocop is happy

Tried to make `config`, `api_response`, `job_results` global variables, but rubocop doesn't like it.